### PR TITLE
Update mls.py to use Auth.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ air = [
 
 setuptools.setup(
     name="skt",
-    version="0.1.57",
+    version="0.1.59",
     author="SKT",
     author_email="all@sktai.io",
     description="SKT package",

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ air = [
     "implicit==0.4.2",
     "tqdm==4.43.0",
     "matplotlib==3.2.1",
+    "mushroom_rl==1.4.0",
 ]
 
 setuptools.setup(

--- a/skt/mls.py
+++ b/skt/mls.py
@@ -29,6 +29,7 @@ def set_model_name(comm_db, params, user="reco"):
     else:  # prd
         url = f"{secret['ab_prd_url']}{MLS_COMPONENTS_API_URL}"
     requests.post(
+        url, json=params, headers={"Authorization": f"Basic {{{secret.get('user_token').get(user)}}}"},
     )
 
 

--- a/skt/mls.py
+++ b/skt/mls.py
@@ -3,7 +3,6 @@ from typing import Dict, Any
 from enum import Enum
 
 import requests
-import json
 import pandas as pd
 import os
 
@@ -18,7 +17,6 @@ S3_DEFAULT_PATH = get_secrets("mls")["s3_model_registry_path"]
 
 EDD_OPTIONS = get_secrets("mls")["edd_options"]
 
-HEADER = {"Content-Type": "application/json"}
 MLS_COMPONENTS_API_URL = "/api/v1/components"
 MLS_META_API_URL = "/api/v1/meta"
 MLS_MLMODEL_API_URL = "/api/v1/models"
@@ -31,9 +29,6 @@ def set_model_name(comm_db, params, user="reco"):
     else:  # prd
         url = f"{secret['ab_prd_url']}{MLS_COMPONENTS_API_URL}"
     requests.post(
-        url,
-        data=json.dumps(params),
-        headers={**{"Authorization": f"Basic {{{secret.get('user_token').get(user)}}}"}, **HEADER},
     )
 
 
@@ -139,7 +134,7 @@ def create_meta_table_item(
     url = get_secrets("mls")[f"ab_{'onprem_' if edd else ''}{aws_env}_url"]
     url = f"{url}{MLS_META_API_URL}/{meta_table}/items"
 
-    response = requests.post(url, headers=HEADER, data=json.dumps(request_data)).json()
+    response = requests.post(url, json=request_data).json()
     results = response.get("results")
 
     if not results:
@@ -176,7 +171,7 @@ def update_meta_table_item(
     url = get_secrets("mls")[f"ab_{'onprem_' if edd else ''}{aws_env}_url"]
     url = f"{url}{MLS_META_API_URL}/{meta_table}/items/{item_name}"
 
-    response = requests.put(url, headers=HEADER, data=json.dumps(request_data)).json()
+    response = requests.put(url, json=request_data).json()
     results = response.get("results")
 
     if not results:
@@ -334,7 +329,7 @@ def update_ml_model_meta(
     request_data["user"] = user
     request_data["model_meta"] = model_meta_dict
 
-    requests.patch(url, headers=HEADER, data=json.dumps(request_data)).json()
+    requests.patch(url, json=request_data).json()
 
 
 def pandas_to_meta_table(


### PR DESCRIPTION
Closes #98 

기존 mls.py의 메소드 중 `set_model_name / get_recent_model_path / get_model_name`의 API변경 및 Auth.인증 추가를 진행하였습니다.

일단 진행하고보니 몇 가지 이슈가 있는데 @chulhankim 휴가 돌아오시면 논의 하면 좋을 것 같습니다


**[1. mls-ab의 REST API 중 `/api/v1/components`는 `model_key`이 아닌 `id`로 GET함]**
- skt패키지의 `get_recent_model_path / get_model_name`는 `model_key`을 이용하여 MLComponents를 조회하는 방식인데, mls-ab REST API에선 id로 조회할 수 밖에 없음
- mls-ab에 `model_key`를 이용하여 GET하는 REST API를 추가하는 것도 방법이나, 일단은 mls.py에 `get_all_recent_model_path`함수를 새로 만들고, 여기에서 `model_key`를 조회하는 방식을 이용

**[2. 기존 mls.py의 함수명의 혼란 및 기능중복]**
- `get_recent_model_path / get_model_name`는 모두 MLComponents의 특정 `model_key`의 `info`값을 가져오는 기능입니다만, 하나는 model_path, 하나는 model_name으로 메소드 명에서 혼란이 생깁니다.
- `get_model_name`을 지우려고 했는데 reco팀 legacy코드에서 계속 활용중이라 지우면 안된다고 하더라구요. 이거 계속 병행해서 갈 지 reco에 가이드를 할 지 고민됩니다.
- 그리고 현재 reco팀에서는 `info`에 모델바이너리 path를 이용하는 중인데, 과거에는 모델명을 적어서 사용한 경우도 있어서 함수명이 `get_recent_model_path`맞을지도 모르겠네요. `get_recent_mode_info`가 더 적절하지 않을까 싶은데 의견 부탁드립니다.
- `set_model_name`도 같은 이슈로 `set_model_info`가 맞지 않을까 싶습니다.

리뷰 부탁드립니다.
