### PR TITLE
Hotfix google cloud bigquery storage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ air = [
 
 setuptools.setup(
     name="skt",
-    version="0.2.38",
+    version="0.2.39",
     author="SKT",
     author_email="all@sktai.io",
     description="SKT package",
@@ -60,7 +60,7 @@ setuptools.setup(
         "pycryptodome",
         "tabulate>=0.8.7",
         "pandas_gbq>=0.13.2",
-        "google-cloud-bigquery-storage",
+        "google-cloud-bigquery-storage<2.0",
         "grpcio<2.0dev",
         "sqlalchemy>=1.3.18",
         "packaging",


### PR DESCRIPTION
google cloud bigqury storage version 2 가 나오면서 하위호환 문제 발생.
이를 해결하기 위해 버전을 1.x 로 강제