### PR TITLE
add saturn table column

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -1,5 +1,5 @@
 all:
-	gcloud builds submit --tag gcr.io/sktaic-datahub/services/etl/etl-api:1.0.0 .
+	gcloud builds submit --tag gcr.io/sktaic-datahub/services/etl/etl-api:1.0.1 .
 test:
 	docker build --no-cache -t etl-api .
 	docker run -p 80:80 -it etl-api

--- a/api/models/saturn_table.py
+++ b/api/models/saturn_table.py
@@ -24,6 +24,7 @@ class SaturnTable(Base):
     period = Column(String(256))
     target_systems = Column(String(256))
     dataset_id = Column(String(1024))
+    source_location = Column(String(1024))
 
     def __repr__(self):
         return f"<Saturn Table: {self.table_id}>"


### PR DESCRIPTION
#238 에서 source_location 필드로 생성 적용

default : null (from data lake)
외부 api를 통해 저장되는 내용은 해당 필드에 api url 적용

gcp sql 상에서 aim-db/etl/saturn_tables 테이블에 해당 컬럼 적용함